### PR TITLE
redmine タグの収集方法をいじりました。

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -13,7 +13,7 @@ module PostsHelper
   end
 
   def format_subject(s, opts={})
-    if s =~ /\A(\[.*\])(.*)/
+    if s =~ /\A((?:\[.*?\])+)(.*)/
       tags = " <span class='redmine_tags'> - #{h $1}</span>"
       "#{h $2.lstrip}#{tags unless opts[:no_tags]}".html_safe
     else


### PR DESCRIPTION
[ruby-trunk - Bug #7300][Open] Hash#[] is imcompatible with 1.9.3 のような subject で Hash#[] までマッチしてしまっていたので。
